### PR TITLE
Implement FourierLayer for higher dimensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,13 +10,13 @@ Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+TensorCore = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
 
 [compat]
 CUDA = "3"
 FFTW = "1"
 Flux = "0.12"
 NNlib = "0.8"
-OMEinsum = "0.6"
 julia = "1.6"
 
 [extras]

--- a/src/FourierLayer.jl
+++ b/src/FourierLayer.jl
@@ -52,7 +52,7 @@ struct FourierLayer{F,Tc<:Complex{<:AbstractFloat},N,Tr<:AbstractFloat,Bf,Bl}
         {F,Tc<:Complex{<:AbstractFloat},N,Tr<:AbstractFloat}
 
         # create the biases with one singleton dimension
-        bf = Flux.create_bias(Wf, bf, 1, size(Wf,2), size(Wf,3))
+        bf = Flux.create_bias(Wf, bf, 1, size(Wf,2), Int.(grid ./ 2 .+ 1)...)
         bl = Flux.create_bias(Wl, bl, 1, size(Wl,1), grid...)
         new{F,Tc,N,Tr,typeof(bf),typeof(bl)}(Wf, Wl, grid, σ, λ, bf, bl)
     end

--- a/src/OperatorLearning.jl
+++ b/src/OperatorLearning.jl
@@ -9,6 +9,7 @@ using Random
 using Random: AbstractRNG
 using Flux: nfan, glorot_uniform, batch
 using OMEinsum
+using NNlib: fast_act
 
 export FourierLayer, DeepONet
 

--- a/src/OperatorLearning.jl
+++ b/src/OperatorLearning.jl
@@ -9,6 +9,7 @@ using Random
 using Random: AbstractRNG
 using Flux: nfan, glorot_uniform, batch
 using OMEinsum
+using TensorCore
 using NNlib: fast_act
 
 export FourierLayer, DeepONet

--- a/src/OperatorLearning.jl
+++ b/src/OperatorLearning.jl
@@ -17,5 +17,6 @@ include("DeepONet.jl")
 include("ComplexWeights.jl")
 include("batched.jl")
 include("subnets.jl")
+include("trainable.jl")
 
 end # module

--- a/src/generated.jl
+++ b/src/generated.jl
@@ -1,0 +1,52 @@
+@generated function (a::FourierLayer)(x::AbstractArray{T,N}) where {T,N}
+    #= Assign the parameters
+    Nothing out of the ordinary here =#
+    params = :(Wf, Wl, bf, bl, σ = a.Wf, a.Wl, a.bf, a.bl, NNlib.fast_act(a.σ, x))
+
+    #= Do a permutation
+    DataLoader requires batch to be the last dim
+    for the rest, it's more convenient to have it in the first one
+    For this we need to generate the permutation tuple first
+    experm evaluates to a tuple (N,1,2,...,N-1) =#
+    experm = :(tuple(N,$:([k for k = 1:N-1]...)))
+    permute = :(xp = permutedims(x, $experm))
+
+    #= The linear path
+    x -> Wl
+    As an argument to the einsum macro we need a list of named grid dimensions
+    grids evaluates to a tuple of names of schema (grid_1, grid_2, ..., grid_N) =#
+    grids = Expr(:tuple, [Symbol("grid_$(i)") for i ∈ 1:N-2]...)
+    linear_mul = :(@ein linear[batch, out, $grids...] := Wl[out, in] * xp[batch, in, $grids...])
+    linear_bias = :(linear .+ bl)
+
+    #= The convolution path
+    x -> 𝔉 -> Wf -> i𝔉
+    Do the Fourier transform (FFT) along the grid dimensions of the input and
+    Multiply the weight tensor with the input using einsum
+    To do the FFT we need to pass the grid dims to perform on
+    fourier_dims evaluates to a tuple of Ints with range 3:N since the grid dims
+    are sequential up to the last dim of the input =#
+    fourier_dims = :(tuple($:([n for n ∈ 3:N])))
+    fourier_mul = :(@ein 𝔉[batch, out, $grids...] := Wf[in, out, $grids...] * fft(xp, $fourier_dims...)[batch, in, $grids...])
+    fourier_bias = :(𝔉 .+ bf)
+
+    #= Do the inverse transform
+    We need to permute back to match the shape of the linear path =#
+    fourier_inv = :(i𝔉 = ifft(𝔉, $fourier_dims...))
+
+    #= Undo the initial permutation
+    experm_inv evaluates to a tuple (2,3,...,N,1) =#
+    experm_inv = :(tuple($:([k for k = 2:N]...),1))
+
+    return Expr(
+        :block,
+        params,
+        permute,
+        linear_mul,
+        linear_bias,
+        fourier_mul,
+        fourier_bias,
+        fourier_inv,
+        :(return permutedims(σ.(linear + i𝔉), $experm_inv))
+    )
+end

--- a/src/trainable.jl
+++ b/src/trainable.jl
@@ -1,0 +1,26 @@
+"""
+A helper function to create ranges of the trainable Fourier modes.
+Those can be parsed and evaluated in order to specify the trainable parameters by Flux
+
+# Input
+The FourierLayer where the trainable modes are required
+
+# Output
+A vector that contains a comma-separated list of ranges for each Fourier dimension:
+
+```julia
+julia> OperatorLearning.train_modes((2,5,12,8))
+4-element Vector{UnitRange}:
+ 1:2
+ 1:5
+ 1:12
+ 1:8
+```
+"""
+function train_modes(λ::Tuple)
+    modes = Array{UnitRange}(undef,length(λ))
+    for (index,numModes) in enumerate(λ)
+        modes[index] = 1:numModes
+    end
+    return modes
+end

--- a/test/fourierlayer.jl
+++ b/test/fourierlayer.jl
@@ -2,11 +2,20 @@ using Test, Random, Flux
 
 @testset "FourierLayer" begin
     @testset "dimensions" begin
-        # Test the proper construction
-        @test size(FourierLayer(128, 64, 100, 20).Wf) == (128, 64, 51)
-        @test size(FourierLayer(128, 64, 100, 20).Wl) == (64, 128)
-        @test size(FourierLayer(128, 64, 100, 20).bf) == (1, 64, 51)
-        @test size(FourierLayer(128, 64, 100, 20).bl) == (1, 64, 100)
+        @testset "1D" begin
+            # Test the proper construction
+            @test size(FourierLayer(128, 64, 100, 20).Wf) == (128, 64, 100)
+            @test size(FourierLayer(128, 64, 100, 20).Wl) == (64, 128)
+            @test size(FourierLayer(128, 64, 100, 20).bf) == (1, 64, 100)
+            @test size(FourierLayer(128, 64, 100, 20).bl) == (1, 64, 100)
+        end
+        @testset "3D" begin
+            # Test the proper construction
+            @test size(FourierLayer(128, 64, (100,150,200), (20,30,40)).Wf) == (128, 64, 100, 150, 200)
+            @test size(FourierLayer(128, 64, (100,150,200), (20,30,40)).Wl) == (64, 128)
+            @test size(FourierLayer(128, 64, (100,150,200), (20,30,40)).bf) == (1, 64, 100, 150, 200)
+            @test size(FourierLayer(128, 64, (100,150,200), (20,30,40)).bl) == (1, 64, 100, 150, 200)
+        end
     end
 
     # Test proper parameter assignment

--- a/test/fourierlayer.jl
+++ b/test/fourierlayer.jl
@@ -11,10 +11,10 @@ using Test, Random, Flux
         end
         @testset "3D" begin
             # Test the proper construction
-            @test size(FourierLayer(128, 64, (100,150,200), (20,30,40)).Wf) == (128, 64, 100, 150, 200)
-            @test size(FourierLayer(128, 64, (100,150,200), (20,30,40)).Wl) == (64, 128)
-            @test size(FourierLayer(128, 64, (100,150,200), (20,30,40)).bf) == (1, 64, 100, 150, 200)
-            @test size(FourierLayer(128, 64, (100,150,200), (20,30,40)).bl) == (1, 64, 100, 150, 200)
+            @test size(FourierLayer(128, 64, (10,15,20), (2,3,4)).Wf) == (128, 64, 10, 15, 20)
+            @test size(FourierLayer(128, 64, (10,15,20), (2,3,4)).Wl) == (64, 128)
+            @test size(FourierLayer(128, 64, (10,15,20), (2,3,4)).bf) == (1, 64, 10, 15, 20)
+            @test size(FourierLayer(128, 64, (10,15,20), (2,3,4)).bl) == (1, 64, 10, 15, 20)
         end
     end
 


### PR DESCRIPTION
So far, `FourierLayer` only works in 1-D. This should be extended to more dimensions, ideally with minimal code repetition.

Replacing the standard implementation by a generated function can do this.