### PR TITLE
Fourier Layer Tests

### DIFF
--- a/test/deeponet.jl
+++ b/test/deeponet.jl
@@ -15,3 +15,20 @@ using Test, Random, Flux
     @test_throws MethodError DeepONet((32.5,64,72), (24,48,72), σ, tanh)
     @test_throws MethodError DeepONet((32,64,72), (24.1,48,72))
 end
+
+#Just the first 16 datapoints from the Burgers' equation dataset
+a = [0.83541104, 0.83479851, 0.83404712, 0.83315711, 0.83212979, 0.83096755, 0.82967374, 0.82825263, 0.82670928, 0.82504949, 0.82327962, 0.82140651, 0.81943734, 0.81737952, 0.8152405, 0.81302771]
+sensors = collect(range(0, 1, length=16))'
+
+model = DeepONet((16, 22, 30), (1, 16, 24, 30), σ, tanh; init_branch=Flux.glorot_normal, bias_trunk=false)
+
+model(a,sensors)
+
+#forward pass
+@test size(model(a, sensors)) == (1, 16)
+
+mgrad = Flux.Zygote.gradient((x,p)->sum(model(x,p)),a,sensors)
+
+#gradients
+@test !iszero(Flux.Zygote.gradient((x,p)->sum(model(x,p)),a,sensors)[1])
+@test !iszero(Flux.Zygote.gradient((x,p)->sum(model(x,p)),a,sensors)[2])

--- a/test/fourierlayer.jl
+++ b/test/fourierlayer.jl
@@ -29,3 +29,26 @@ using Test, Random, Flux
     @test_throws AssertionError FourierLayer(100, 100, 100, 60, σ)
     @test_throws AssertionError FourierLayer(100, 100, 100, 60)
 end
+
+#Just the first 16 data points from Burgers' equation dataset
+xtrain = Float32[0.83541104, 0.83479851, 0.83404712, 0.83315711, 0.83212979, 0.83096755, 0.82967374, 0.82825263, 0.82670928, 0.82504949, 0.82327962, 0.82140651, 0.81943734, 0.81737952, 0.8152405, 0.81302771]
+grid = Float32.(collect(range(0, 1, length=16))')
+
+x = cat(reshape(xtrain,(1,16,1)),
+        reshape(repeat(grid,1),(1,16,1));
+        dims=3)
+
+x = permutedims(x,(3,2,1))
+layer = FourierLayer(64, 64, 16, 8, gelu, bias_fourier=false)
+model = Chain(Dense(2,64;bias=false), layer, layer, layer, layer,
+                Dense(64,2;bias=false))
+
+model(x)
+
+#forward pass
+@test size(model(x)) == (2, 16, 1)
+
+Flux.Zygote.gradient((x)->sum(model(x)), x)
+
+#gradient test
+@test !iszero(Flux.Zygote.gradient((x)->sum(model(x)), x)[1])


### PR DESCRIPTION
I have added a couple of simple tests for Fourier Layer and DeepONet Layer. What more tests can we add for the same?
One thing that I wanted to add for test/deeponet.jl

      model1 = DeepONet((16, 22, 30), (1, 16, 24, 30), σ, tanh; init_branch=Flux.glorot_normal, bias_trunk=false)
      parameters = params(model1)
  
      branch = Chain(Dense(16, 22,init=Flux.glorot_normal), Dense(22, 30,init=Flux.glorot_normal))
      trunk = Chain(Dense(1, 16, bias=false), Dense(16, 24, bias=false), Dense(24, 30, bias=false))
      model2 = DeepONet(branch, trunk)
  
      model1(a,sensors)
      model2(a,sensors)
      #forward pass
      @test model1(a, sensors) ≈ model2(a, sensors)
  
      m1grad = Flux.Zygote.gradient((x,p)->sum(model1(x,p)),a,sensors)
      m2grad = Flux.Zygote.gradient((x,p)->sum(model2(x,p)),a,sensors)
  
      #gradients
      @test !iszero(m1grad)
      @test !iszero(m2grad)
      @test m1grad[1] ≈ m2grad[1] rtol=1e-12
      @test m1grad[2] ≈ m2grad[2] rtol=1e-12

but the problem is, making the parameters same for model1 and model2 doesn't seem feasible here. Besides, I wanted to know how to formulate a test for training of FNO and DeepONet?