### PR TITLE
Update for Flux 0.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OperatorLearning"
 uuid = "5913d0e6-5bb6-45e3-8a06-341cf4fd0203"
 authors = ["Patrick Zimbrod <76100656+pzimbrod@users.noreply.github.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -14,7 +14,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 CUDA = "3"
 FFTW = "1"
-Flux = "0.12"
+Flux = "0.12, 0.13"
 NNlib = "0.8"
 OMEinsum = "0.6"
 julia = "1.6"

--- a/test/fourierlayer.jl
+++ b/test/fourierlayer.jl
@@ -13,13 +13,13 @@ using Test, Random, Flux
     # We only use a subset of the weight tensors for training
     @testset "parameters" begin
         # Wf
-        @test size(params(FourierLayer(128, 64, 100, 20))[1]) == (128, 64, 20)
+        @test size(Flux.params(FourierLayer(128, 64, 100, 20))[1]) == (128, 64, 20)
         # Wl
-        @test size(params(FourierLayer(128, 64, 100, 20))[2]) == (64, 128)
+        @test size(Flux.params(FourierLayer(128, 64, 100, 20))[2]) == (64, 128)
         # bf
-        @test size(params(FourierLayer(128, 64, 100, 20))[3]) == (1, 64, 20)
+        @test size(Flux.params(FourierLayer(128, 64, 100, 20))[3]) == (1, 64, 20)
         # bl
-        @test size(params(FourierLayer(128, 64, 100, 20))[4]) == (1, 64, 100)
+        @test size(Flux.params(FourierLayer(128, 64, 100, 20))[4]) == (1, 64, 100)
     end
 
     # Accept only Int as architecture parameters


### PR DESCRIPTION
Flux no longer exports `params`. It has downstream tests of this package, so this will let us see if anything else breaks. 